### PR TITLE
Java EE 7 compliant BOM proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/.project

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 # Temporary Files #
 .mtj.tmp/
 
-# Eclipse specific Files #
+# Eclipse Files #
+/.settings
 /.classpath
 /.project
 
@@ -15,4 +16,3 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
+# Class Files #
 *.class
 
-# Mobile Tools for Java (J2ME)
+# Temporary Files #
 .mtj.tmp/
+
+# Eclipse specific Files #
+/.classpath
+/.project
 
 # Package Files #
 *.jar
@@ -10,4 +15,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-/.project
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # microprofile-bom
-Top level github repo for defining the content of the MicroProfile deliverables.
+MicroProfile Bill of Materials (BOM) - All project artifacts with their respective versions. For dependency management into other modules and applications.
+
+[![License](http://img.shields.io/badge/license-Apache2-red.svg)](http://opensource.org/licenses/apache-2.0)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016, 2017 Werner Keil and others.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.
+
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <!-- We could use this parent if we want <parent> <groupId>org.sonatype.oss</groupId> 
+        <artifactId>oss-parent</artifactId> <version>9</version> </parent> -->
+
+    <groupId>io.microprofile</groupId>
+    <artifactId>microprofile-bom</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>MicroProfile Bill of Materials</name>
+    <description>MicroProfile Bill of Materials (BOM)</description>
+    <inceptionYear>2016</inceptionYear>
+    <organization>
+        <name>Microprofile.io</name>
+        <url>http://www.microprofile.io</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/microprofile/microprofile-bom.git</connection>
+        <developerConnection>scm:git:git@github.com:microprofile/microprofile-bom.git</developerConnection>
+        <url>http://github.com/microprofile/microprofile-bom</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/microprofile/microprofile-bom/issues</url>
+    </issueManagement>
+    <mailingLists>
+        <mailingList>
+            <name>MicroProfile</name>
+            <subscribe>http://groups.google.com/group/microprofile/subscribe</subscribe>
+            <post>microprofile@googlegroups.com</post>
+        </mailingList>
+    </mailingLists>
+
+    <properties>
+        <cdi.version>1.1</cdi.version>
+        <javax.inject.version>1</javax.inject.version>
+        <javax.json.version>1.0</javax.json.version>
+        <javax.jaxrs.version>2.0</javax.jaxrs.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>javax.enterprise</groupId>
+                <artifactId>cdi-api</artifactId>
+                <version>${cdi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>${javax.inject.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>${javax.json.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>${javax.jaxrs.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
 
     <properties>
         <cdi.version>1.1</cdi.version>
-        <javax.inject.version>1</javax.inject.version>
         <javax.json.version>1.0</javax.json.version>
         <javax.jaxrs.version>2.0</javax.jaxrs.version>
     </properties>
@@ -76,12 +75,6 @@
                 <groupId>javax.enterprise</groupId>
                 <artifactId>cdi-api</artifactId>
                 <version>${cdi.version}</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>${javax.inject.version}</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,23 +76,25 @@
                 <groupId>javax.enterprise</groupId>
                 <artifactId>cdi-api</artifactId>
                 <version>${cdi.version}</version>
-                <scope>provided</scope>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>${javax.inject.version}</version>
-                <scope>provided</scope>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>javax.json</groupId>
                 <artifactId>javax.json-api</artifactId>
                 <version>${javax.json.version}</version>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>${javax.jaxrs.version}</version>
+                <scope>compile</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.microprofile</groupId>
     <artifactId>microprofile-bom</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
     <name>MicroProfile Bill of Materials</name>
     <description>MicroProfile Bill of Materials (BOM)</description>


### PR DESCRIPTION
Can't say for sure, if we want to deviate from Java EE 7 for some of the 3 components, but this proposal sticks to the exact versions in `javaee-web-api : 7.0` (the smaller subset of javaee-api)